### PR TITLE
[SLUB-45] feat : 실시간 채팅 구현

### DIFF
--- a/chamchimayo-api/build.gradle
+++ b/chamchimayo-api/build.gradle
@@ -4,6 +4,11 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-thymeleaf')
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
 
+    //chat
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
     //security
     implementation('org.springframework.boot:spring-boot-starter-oauth2-client')
     implementation('org.springframework.boot:spring-boot-starter-security')

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/config/ListenerConfig.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/config/ListenerConfig.java
@@ -1,0 +1,43 @@
+package com.slub.chamchimayo.chat.config;
+
+import com.slub.chamchimayo.chat.dto.response.MessageResponse;
+import com.slub.chamchimayo.chat.constants.KafkaConstants;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class ListenerConfig {
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, MessageResponse> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, MessageResponse> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, MessageResponse> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(), new JsonDeserializer<>(MessageResponse.class));
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigurations() {
+        Map<String, Object> configurations = new HashMap<>();
+        configurations.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConstants.KAFKA_BROKER);
+        configurations.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaConstants.GROUP_ID);
+        configurations.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configurations.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configurations.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        return configurations;
+    }
+}

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/config/ProducerConfiguration.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/config/ProducerConfiguration.java
@@ -1,0 +1,40 @@
+package com.slub.chamchimayo.chat.config;
+
+import com.slub.chamchimayo.chat.dto.response.MessageResponse;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class ProducerConfiguration {
+
+    @Bean
+    public ProducerFactory<String, MessageResponse> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigurations());
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigurations() {
+        Map<String, Object> configurations = new HashMap<>();
+        configurations.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configurations.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configurations.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return configurations;
+    }
+
+    @Bean
+    public KafkaTemplate<String, MessageResponse> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}
+

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/config/WebSocketConfig.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/config/WebSocketConfig.java
@@ -1,0 +1,20 @@
+package com.slub.chamchimayo.chat.config;
+
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 접속 주소 -> ws://localhost:8080/ws-chat
+        registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/app"); // 메시지 발행 요청 prefix
+        registry.enableSimpleBroker("/topic"); // 메시지 구독 요청 prefix
+    }
+}

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/constants/KafkaConstants.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/constants/KafkaConstants.java
@@ -1,0 +1,8 @@
+package com.slub.chamchimayo.chat.constants;
+
+public class KafkaConstants {
+
+    public static final String KAFKA_TOPIC = "kafka-chat";
+    public static final String GROUP_ID = "kafka-sandbox";
+    public static final String KAFKA_BROKER = "localhost:9092";
+}

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/consumer/MessageListener.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/consumer/MessageListener.java
@@ -1,0 +1,27 @@
+package com.slub.chamchimayo.chat.consumer;
+
+import com.slub.chamchimayo.chat.dto.response.MessageResponse;
+import com.slub.chamchimayo.chat.constants.KafkaConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MessageListener {
+
+    private final SimpMessagingTemplate template;
+
+    // 메시지가 토픽에 오면 springboot가 자동으로 메소드 호출
+    @KafkaListener(
+            topics = KafkaConstants.KAFKA_TOPIC,
+            groupId = KafkaConstants.GROUP_ID
+    )
+    public void listen(MessageResponse messageResponse) {
+        log.info("sending via kafka listener..");
+        template.convertAndSend("/topic/room/" + messageResponse.getRoomId(), messageResponse);
+    }
+}

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/controller/ChatController.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/controller/ChatController.java
@@ -1,0 +1,32 @@
+package com.slub.chamchimayo.chat.controller;
+
+import com.slub.chamchimayo.chat.dto.request.MessageRequest;
+import com.slub.chamchimayo.chat.dto.response.MessageResponse;
+import com.slub.chamchimayo.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping(value = "/api/send", consumes = "application/json", produces = "application/json")
+    public void sendMessage(@RequestBody MessageRequest messageRequest) {
+        chatService.sendMessage(messageRequest);
+    }
+
+    @GetMapping("/data")
+    public ResponseEntity<List<MessageResponse>> getMessages(@RequestParam Long lastMessageId,
+                                                             @RequestParam int size,
+                                                             @RequestParam Long roomId) {
+
+        List<MessageResponse> messageResponses = chatService.fetchMessagePagesBy(lastMessageId, size, roomId);
+        return new ResponseEntity<>(messageResponses, HttpStatus.OK);
+    }
+}

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/service/ChatService.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/service/ChatService.java
@@ -1,0 +1,61 @@
+package com.slub.chamchimayo.chat.service;
+
+import com.slub.chamchimayo.chat.constants.KafkaConstants;
+import com.slub.chamchimayo.chat.dto.request.MessageRequest;
+import com.slub.chamchimayo.chat.dto.response.MessageResponse;
+import com.slub.chamchimayo.chat.entity.Message;
+import com.slub.chamchimayo.chat.enumclass.MessageType;
+import com.slub.chamchimayo.chat.repository.ChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class ChatService {
+
+    private final KafkaTemplate<String, MessageResponse> kafkaTemplate;
+
+    private final ChatRepository chatRepository;
+
+    public void sendMessage(MessageRequest messageRequest) {
+
+        messageRequest.setTimestamp(LocalDateTime.now().toString());
+        if(messageRequest.getType() == MessageType.ENTER){
+            messageRequest.setContent(messageRequest.getSender() + "님이 입장하셨습니다.");
+            messageRequest.setSender("[알림]");
+        }
+        else if(messageRequest.getType() == MessageType.EXIT) {
+            messageRequest.setContent(messageRequest.getSender() + "님이 퇴장하셨습니다.");
+            messageRequest.setSender("[알림]");
+        }
+        Message message = chatRepository.save(messageRequest.toEntity());
+        try {
+            // post 요청으로 전달받은 메시지를 해당 카프카 토픽에 생산
+            kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, MessageResponse.from(message)).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<MessageResponse> fetchMessagePagesBy(Long lastMessageId, int size, Long roomId) {
+        Page<Message> messages = fetchPages(lastMessageId, size, roomId);
+        return messages.getContent()
+                .stream()
+                .map(message -> MessageResponse.from(message))
+                .collect(Collectors.toList());
+    }
+
+    private Page<Message> fetchPages(Long lastMessageId, int size, Long roomId) {
+        PageRequest pageRequest = PageRequest.of(0, size);
+        return chatRepository.findByIdLessThanAndRoomIdOrderByIdDesc(lastMessageId, roomId, pageRequest);
+    }
+
+}

--- a/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/service/ChatService.java
+++ b/chamchimayo-api/src/main/java/com/slub/chamchimayo/chat/service/ChatService.java
@@ -4,7 +4,6 @@ import com.slub.chamchimayo.chat.constants.KafkaConstants;
 import com.slub.chamchimayo.chat.dto.request.MessageRequest;
 import com.slub.chamchimayo.chat.dto.response.MessageResponse;
 import com.slub.chamchimayo.chat.entity.Message;
-import com.slub.chamchimayo.chat.enumclass.MessageType;
 import com.slub.chamchimayo.chat.repository.ChatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,7 +11,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -27,15 +25,7 @@ public class ChatService {
 
     public void sendMessage(MessageRequest messageRequest) {
 
-        messageRequest.setTimestamp(LocalDateTime.now().toString());
-        if(messageRequest.getType() == MessageType.ENTER){
-            messageRequest.setContent(messageRequest.getSender() + "님이 입장하셨습니다.");
-            messageRequest.setSender("[알림]");
-        }
-        else if(messageRequest.getType() == MessageType.EXIT) {
-            messageRequest.setContent(messageRequest.getSender() + "님이 퇴장하셨습니다.");
-            messageRequest.setSender("[알림]");
-        }
+        messageRequest.parsing();
         Message message = chatRepository.save(messageRequest.toEntity());
         try {
             // post 요청으로 전달받은 메시지를 해당 카프카 토픽에 생산

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/dto/request/MessageRequest.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/dto/request/MessageRequest.java
@@ -1,0 +1,47 @@
+package com.slub.chamchimayo.chat.dto.request;
+
+import com.slub.chamchimayo.chat.entity.Message;
+import com.slub.chamchimayo.chat.enumclass.MessageType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MessageRequest {
+
+    private Long id;
+
+    private MessageType type;
+
+    private Long roomId;
+
+    private String sender;
+
+    private String content;
+
+    private String timestamp;
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @Builder
+    public Message toEntity() {
+        return Message.builder()
+                .type(this.type)
+                .roomId(this.roomId)
+                .sender(this.sender)
+                .content(this.content)
+                .timestamp(this.timestamp)
+                .build();
+    }
+}

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/dto/request/MessageRequest.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/dto/request/MessageRequest.java
@@ -2,12 +2,11 @@ package com.slub.chamchimayo.chat.dto.request;
 
 import com.slub.chamchimayo.chat.entity.Message;
 import com.slub.chamchimayo.chat.enumclass.MessageType;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 public class MessageRequest {
 
     private Long id;
@@ -22,19 +21,6 @@ public class MessageRequest {
 
     private String timestamp;
 
-    public void setTimestamp(String timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public void setSender(String sender) {
-        this.sender = sender;
-    }
-
-    public void setContent(String content) {
-        this.content = content;
-    }
-
-    @Builder
     public Message toEntity() {
         return Message.builder()
                 .type(this.type)
@@ -43,5 +29,17 @@ public class MessageRequest {
                 .content(this.content)
                 .timestamp(this.timestamp)
                 .build();
+    }
+
+    public void parsing() {
+        this.timestamp = LocalDateTime.now().toString();
+        if(this.type == MessageType.ENTER){
+            this.content = this.sender + "님이 입장하셨습니다.";
+            this.sender = "[알림]";
+        }
+        else if(this.type == MessageType.EXIT) {
+            this.content = this.sender + "님이 퇴장하셨습니다.";
+            this.sender = "[알림]";
+        }
     }
 }

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/dto/response/MessageResponse.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/dto/response/MessageResponse.java
@@ -1,0 +1,38 @@
+package com.slub.chamchimayo.chat.dto.response;
+
+import com.slub.chamchimayo.chat.entity.Message;
+import com.slub.chamchimayo.chat.enumclass.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MessageResponse {
+
+    private Long id;
+
+    private MessageType type;
+
+    private Long roomId;
+
+    private String sender;
+
+    private String content;
+
+    private String timestamp;
+
+    public static MessageResponse from(Message message) {
+        return MessageResponse.builder()
+                .id(message.getId())
+                .type(message.getType())
+                .roomId(message.getRoomId())
+                .sender(message.getSender())
+                .content(message.getContent())
+                .timestamp(message.getTimestamp())
+                .build();
+    }
+}

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/entity/Message.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/entity/Message.java
@@ -1,0 +1,40 @@
+package com.slub.chamchimayo.chat.entity;
+
+import com.slub.chamchimayo.chat.enumclass.MessageType;
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Entity
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private MessageType type;
+
+    private Long roomId;
+
+    private String sender;
+
+    private String content;
+
+    private String timestamp;
+
+    @Builder
+    public Message(MessageType type, Long roomId, String sender, String content, String timestamp) {
+        this.type = type;
+        this.roomId = roomId;
+        this.sender = sender;
+        this.content = content;
+        this.timestamp = timestamp;
+    }
+}

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/entity/Message.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/entity/Message.java
@@ -9,7 +9,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 @Entity

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/enumclass/MessageType.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/enumclass/MessageType.java
@@ -1,0 +1,11 @@
+package com.slub.chamchimayo.chat.enumclass;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MessageType {
+
+    ENTER, TALK, EXIT
+}

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/enumclass/MessageType.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/enumclass/MessageType.java
@@ -1,10 +1,5 @@
 package com.slub.chamchimayo.chat.enumclass;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
 public enum MessageType {
 
     ENTER, TALK, EXIT

--- a/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/repository/ChatRepository.java
+++ b/chamchimayo-common/src/main/java/com/slub/chamchimayo/chat/repository/ChatRepository.java
@@ -1,0 +1,14 @@
+package com.slub.chamchimayo.chat.repository;
+
+import com.slub.chamchimayo.chat.entity.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Message, Long> {
+
+    Page<Message> findByIdLessThanAndRoomIdOrderByIdDesc(Long lastMessageId, Long roomId, Pageable pageable);
+}
+


### PR DESCRIPTION
WebSocket + Stomp + Kafka 를 활용한 실시간 채팅 구현

- pub/sub 구조의 멀티 채팅룸 관리
- 1개의 topic, 1개의 partition, 1개의 replication
- 팀 별 채팅기능 구현
- 입장, 퇴장 메세지 구현
- DB 메세지 저장 구현
- 무한 스크롤 JPA Pagination 구현 (향후 프론트와 논의 및 수정)